### PR TITLE
Custom element POC for #1

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
     </div>
 
     <div class="demo">
-      <div class="dual-range-input">
+      <dual-range-input>
         <input type="range" min="0" max="100" step="1" value="25">
         <input type="range" min="0" max="100" step="1" value="75">
-      </div>
+      </dual-range-input>
       <pre class="values"></pre>
     </div>
     <p>
@@ -52,10 +52,10 @@
     </p>
 
     <div class="demo demo--purple">
-      <div class="dual-range-input">
+      <dual-range-input>
         <input type="range" min="20" max="30" step="0.1" value="20">
         <input type="range" min="20" max="30" step="0.1" value="25.5">
-      </div>
+      </dual-range-input>
       <pre class="values"></pre>
     </div>
     <div class="demo demo--pink">

--- a/lib/index.scss
+++ b/lib/index.scss
@@ -57,6 +57,7 @@
   width: var(--dri-thumb-width);
 }
 
+dual-range-input,
 .dual-range-input {
   --dri-thumb-width: 1.25rem;
   --dri-thumb-height: 1.25rem;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-class DualRangeInput {
+class DualRangeInput extends HTMLElement {
   $min: HTMLInputElement;
   $max: HTMLInputElement;
   precision: number;
@@ -13,9 +13,20 @@ class DualRangeInput {
     $max: HTMLInputElement,
     precision: number = 3
   ) {
-    this.$min = $min;
-    this.$max = $max;
-    this.precision = precision;
+    super();
+
+    this.$min =
+      $min ||
+      this.querySelector('#min') ||
+      document.querySelectorAll('input')?.item(0) ||
+      document.createElement('input');
+    this.$max =
+      $max ||
+      this.querySelector('#max') ||
+      document.querySelectorAll('input')?.item(1) ||
+      document.createElement('input');
+    this.precision =
+      precision || parseInt(this.getAttribute('precision') || '3');
 
     this.$min.addEventListener('input', this.updateCeil);
     this.$max.addEventListener('input', this.updateFloor);
@@ -88,3 +99,5 @@ class DualRangeInput {
 }
 
 export default DualRangeInput;
+
+customElements.define('dual-range-input', DualRangeInput);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stanko/dual-range-input",
   "description": "Native dual-range input in about fifty lines of JavaScript",
-  "version": "0.9.8",
+  "version": "0.9.8-custom-element",
   "private": false,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fairly minimal changes to support using `dual-range-input` as a custom element as well as a standalone class. I'm sure there's more that could be done to make it more custom element-y.

(The `.createElement()` fallback is just there to satisfy TypeScript; it's not functional otherwise.)